### PR TITLE
Allow more entities than 4294967295

### DIFF
--- a/lent.h
+++ b/lent.h
@@ -24,4 +24,5 @@ this is Imperial Royal Guard guarding this header
 #ifdef ENTITY_COMMENT 
 entity 
 #endif
-typedef unsigned int lent_entity;
+#include <boost/multiprecision/cpp_int.hpp>
+typedef uint1024_t lent_entity;


### PR DESCRIPTION
This PR allows more than 4294967295 entities, as it is a serious current limitation. This addresses https://github.com/nem0/lent/issues/5

There's a minor dependency on boost but it is easy to download from here:
https://www.boost.org/users/download/